### PR TITLE
feat: implementar landing page pública e fluxo de cadastro por perfil

### DIFF
--- a/Rec/Rec/settings.py
+++ b/Rec/Rec/settings.py
@@ -117,9 +117,10 @@ STATIC_URL = "static/"
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
-LOGIN_REDIRECT_URL = "/"
-LOGOUT_REDIRECT_URL = "/"
+
 LOGIN_URL = "login"
+LOGIN_REDIRECT_URL = "reciclAI:dashboard"
+LOGOUT_REDIRECT_URL = "reciclAI:public_index"
 
 CSRF_TRUSTED_ORIGINS = (
     [f"https://{os.environ.get('WEB_HOST')}"] if "WEB_HOST" in os.environ else []

--- a/Rec/reciclAI/forms.py
+++ b/Rec/reciclAI/forms.py
@@ -1,14 +1,55 @@
 from django import forms
-from .models import Collection, Residue
+from django.contrib.auth.forms import UserCreationForm
+from django.contrib.auth.models import User
+from django.db import transaction
+from .models import Profile, Residue, Collection
 
 
-class CollectionStatusForm(forms.ModelForm):
-    class Meta:
-        model = Collection
-        fields = ["status"]
+class CustomUserCreationForm(UserCreationForm):
+    USER_TYPE_CHOICES = (
+        ("C", "Cidadão"),
+        ("L", "Coletor"),
+        ("R", "Recicladora"),
+    )
+    user_type = forms.ChoiceField(
+        label="Tipo de Perfil",
+        choices=USER_TYPE_CHOICES,
+        widget=forms.RadioSelect,
+        required=True,
+    )
+
+    class Meta(UserCreationForm.Meta):
+        model = User
+        # Removido 'user_type' daqui, pois não pertence ao modelo User
+        fields = UserCreationForm.Meta.fields
+
+    @transaction.atomic
+    def save(self, commit=True):
+        user = super().save(commit=False)
+        # O UserCreationForm lida com a hash da senha ao salvar
+        if commit:
+            user.save()
+            # Cria o perfil do usuário com o tipo selecionado
+            Profile.objects.create(
+                user=user, user_type=self.cleaned_data.get("user_type")
+            )
+        return user
 
 
 class ResidueForm(forms.ModelForm):
     class Meta:
         model = Residue
         fields = ["residue_type", "weight", "units", "location"]
+        labels = {
+            "residue_type": "Tipo de Resíduo",
+            "weight": "Peso (kg)",
+            "units": "Unidades",
+            "location": "Endereço de Coleta",
+        }
+
+
+class CollectionStatusForm(forms.ModelForm):
+    class Meta:
+        model = Collection
+        fields = ["status"]
+        labels = {"status": "Atualizar Status da Coleta"}

--- a/Rec/reciclAI/signals.py
+++ b/Rec/reciclAI/signals.py
@@ -1,21 +1,11 @@
-from django.db.models.signals import post_save
-from django.contrib.auth.models import User
-from django.dispatch import receiver
-from .models import Profile
+from django.apps import AppConfig
 
 
-@receiver(post_save, sender=User)
-def create_user_profile(sender, instance, created, **kwargs):
-    """
-    Cria um Profile automaticamente para cada novo User.
-    """
-    if created:
-        Profile.objects.create(user=instance, user_type="C")  # 'C' como padrão
+class CoreConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "ReciclAI"
 
-
-@receiver(post_save, sender=User)
-def save_user_profile(sender, instance, **kwargs):
-    """
-    Salva o Profile associado sempre que o User for salvo.
-    """
-    instance.profile.save()
+    def ready(self):
+        # Desativado para centralizar a criação de perfil no formulário de cadastro
+        # import core.signals
+        pass

--- a/Rec/reciclAI/templates/base.html
+++ b/Rec/reciclAI/templates/base.html
@@ -12,7 +12,7 @@
   <body>
     <nav class="navbar navbar-expand-lg navbar-light bg-light">
       <div class="container-fluid">
-        <a class="navbar-brand" href="{% url 'reciclAI:index' %}">Reciclaí</a>
+        <a class="navbar-brand" href="{% url 'reciclAI:public_index' %}">Reciclaí</a>
         <button
           class="navbar-toggler"
           type="button"

--- a/Rec/reciclAI/templates/reciclAI/public_index.html
+++ b/Rec/reciclAI/templates/reciclAI/public_index.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %} {% block title %}Bem-vindo ao Reciclaí{% endblock %} {% block content %}
+<div class="container text-center mt-5">
+  <div class="jumbotron">
+    <h1 class="display-4">Reciclaí</h1>
+    <p class="lead">Conectando quem recicla com quem coleta.</p>
+    <hr class="my-4" />
+    <p>
+      Nossa plataforma simplifica o processo de coleta seletiva, incentivando cidadãos com um
+      sistema de pontos e recompensas, otimizando a rota de coletores e gerenciando o recebimento de
+      materiais para recicladoras.
+    </p>
+    <div class="mt-4">
+      <a class="btn btn-primary btn-lg" href="{% url 'reciclAI:signup' %}" role="button">
+        Cadastre-se Agora
+      </a>
+      <a class="btn btn-secondary btn-lg" href="{% url 'login' %}" role="button">Fazer Login</a>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/Rec/reciclAI/templates/reciclAI/recycler_received.html
+++ b/Rec/reciclAI/templates/reciclAI/recycler_received.html
@@ -1,5 +1,10 @@
-{% extends 'base.html' %} {% block title %}Resíduos Recebidos - {{ block.super }}{% endblock %} {%
-block content %}
+{% extends "base.html" %}
+
+{% block title %}
+Resíduos Recebidos - {{ block.super }}
+{% endblock %}
+
+{% block content %}
 <div class="container mt-4">
   <h1 class="mb-4">Resíduos Recebidos</h1>
 
@@ -13,8 +18,9 @@ block content %}
       </div>
       <p class="mb-1">Cidadão: {{ collection.residue.citizen.username }}</p>
       <p class="mb-1">Localização: {{ collection.residue.location }}</p>
+
       <a
-        href="{% url 'reciclAI:recycler_process' collection.residue.id %}"
+        href="{% url 'reciclAI:recycler_process' residue_id=collection.residue.id %}"
         class="btn btn-primary mt-2"
       >
         Processar

--- a/Rec/reciclAI/urls.py
+++ b/Rec/reciclAI/urls.py
@@ -1,11 +1,14 @@
 from django.urls import path
 from . import views
 
-app_name = "core"
+app_name = "reciclAI"
 
 urlpatterns = [
-    path("", views.index, name="index"),
+    # Rotas Públicas
+    path("", views.public_index, name="public_index"),
     path("signup/", views.signup, name="signup"),
+    # Rota de Dashboard (pós-login)
+    path("dashboard/", views.dashboard, name="dashboard"),
     # URLs do Cidadão
     path("residue/create/", views.residue_create, name="residue_create"),
     path("collection/status/", views.collection_status, name="collection_status"),


### PR DESCRIPTION
Este PR implementa a landing page pública da aplicação e o novo fluxo de cadastro com seleção de perfil (cidadão, coletor ou recicladora). 

Após o registro, o usuário é autenticado automaticamente e redirecionado para a interface específica do tipo de perfil escolhido.

Funcionalidades incluídas:
- Landing page pública com opções de login e cadastro
- Formulário de signup com username, senha e escolha de perfil
- Autenticação automática pós-cadastro
- Redirecionamento dinâmico baseado no tipo de usuário
- Ajustes de templates e rotas
- Organização das views e URLs do fluxo inicial

Closes: #57 #58 #59
